### PR TITLE
docs: add a `.env.template` file

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,4 @@
+# Steps:
+# 1) Copy the contents of this file via `cp .env.template .env`
+# 2) Add your OpenAPI key in the `.env` file (not in `.env.template`)
+OPENAI_API_KEY=add_your_api_key_here

--- a/README.md
+++ b/README.md
@@ -73,4 +73,26 @@ pip install -r requirements.txt
 
 Run the prepare exercise notebook (found inside the [exercises folder](https://github.com/dair-ai/maven-pe-for-llms-9/blob/main/exercises/PE_for_LLMs_Preparation_Exercise.ipynb)). Before attempting the preparation exercise, add a `.env` file to your root folder and add your `OPENAI_API_KEY`.
 
+Create a `.env` file by copying `.env.template`:
+```sh 
+cp .env.template .env
+```
+
+Add your OpenAI API key to the `.env` file (not the .env.template file).
+
+Start a local Jupyter Lab server:
+```sh
+jupyter lab .
+```
+
+Execute the code in `exercises/PE_for_LLMs_Preparation_Exercise.py`. If you see an output similar to the following everything works as intended:
+
+```
+positive
+neutral
+neutral
+positive
+```
+
+
 That's it! You're all set to start working on the notebooks and exercises.


### PR DESCRIPTION
Proposal:
add a `.env.template` file, add instructions for creating the `.env` file and starting a local Jupyter server.

People might need a little extra help to know what the `.env` file should look like. It is a common practice to include a `.env.template` file in the repository with the expected keys (but not the sensitive values) that can be used as a blueprint.